### PR TITLE
Builds and signs service images continuiously

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ pipelines:
 	@fly --target boutique set-pipeline --pipeline emailservice --config ci/concourse/emailservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline emailservice
 	@fly --target boutique set-pipeline --pipeline frontend --config ci/concourse/frontend/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline frontend
 	@fly --target boutique set-pipeline --pipeline paymentservice --config ci/concourse/paymentservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline paymentservice
+	@fly --target boutique set-pipeline --pipeline productcatalogservice --config ci/concourse/productcatalogservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline productcatalogservice
 	@fly --target boutique set-pipeline --pipeline recommendationservice --config ci/concourse/recommendationservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline recommendationservice
 	@fly --target boutique set-pipeline --pipeline shippingservice --config ci/concourse/shippingservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline shippingservice
 

--- a/ci/concourse/adservice/pipeline.yaml
+++ b/ci/concourse/adservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/adservice/**
 - name: image

--- a/ci/concourse/cartservice/pipeline.yaml
+++ b/ci/concourse/cartservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/cartservice/**
 - name: image

--- a/ci/concourse/checkoutservice/pipeline.yaml
+++ b/ci/concourse/checkoutservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/checkoutservice/**
 - name: image

--- a/ci/concourse/currencyservice/pipeline.yaml
+++ b/ci/concourse/currencyservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/currencyservice/**
 - name: image

--- a/ci/concourse/emailservice/pipeline.yaml
+++ b/ci/concourse/emailservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/emailservice/**
 - name: image

--- a/ci/concourse/frontend/pipeline.yaml
+++ b/ci/concourse/frontend/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/frontend/**
 - name: image

--- a/ci/concourse/paymentservice/pipeline.yaml
+++ b/ci/concourse/paymentservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/paymentservice/**
 - name: image

--- a/ci/concourse/productcatalogservice/pipeline.yaml
+++ b/ci/concourse/productcatalogservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/productcatalogservice/**
 - name: image

--- a/ci/concourse/recommendationservice/pipeline.yaml
+++ b/ci/concourse/recommendationservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/recommendationservice/**
 - name: image

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/adservice/**
 - name: release

--- a/ci/concourse/shippingservice/pipeline.yaml
+++ b/ci/concourse/shippingservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
+    uri: https://github.com/crdant/microservices-demo.git
     paths: 
     - src/shippingservice/**
 - name: image


### PR DESCRIPTION
TL;DR
-----

Enables CI/CD for each microservice

Details
-------

Implements pipelines that build and sign all 10 microservice as the first step toward showing end-to-end CI/CD for the entire application.

To create the pipelins, run `make pipelines`.
