### PR TITLE
Fixes semantic version bump

### DIFF
--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -300,9 +300,8 @@ jobs:
     trigger: true
     passed:
     - verify-shippingservice
-  - put: version
+  - get: version
     params:
-      get_latest: true
       bump: patch
   - load_var: version
     file: version/version

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -342,7 +342,7 @@ jobs:
 
             function update_image_hash() {
               service=${1}
-              digest=$(cat ${SERVICE}/digest)
+              digest=$(cat ${service}/digest)
               yq -i ".spec.values.images.tag = \"edge@${digest}\"" source/manifests/${service}-chart.yaml
             }
             umask 077


### PR DESCRIPTION
TL;DR
-----

Restores semantic version tracking

Details
-------

Updates the `prepare-release` job to correctly bump the semver and save the change.
