### PR TITLE
Worksaround registry proxy issue

### DIFF
--- a/manifests/kots-app.yaml
+++ b/manifests/kots-app.yaml
@@ -18,8 +18,8 @@ spec:
     - deployment/recommendationservice
     - deployment/redis-cart
     - deployment/shippingservice
-  replicatedRegistryDomain: registry.shortrib.io
-  proxyRegistryDomain: proxy.shortrib.io
+  # replicatedRegistryDomain: registry.shortrib.io
+  # proxyRegistryDomain: proxy.shortrib.io
   ports:
     - serviceName: frontend
       servicePort: 80


### PR DESCRIPTION
TL;DR
-----

Temporarily removes custom registry domains

Details
-------

Removes the custom `shortrib.io` domains from the Replicated
registry and registry proxy as a workaround for proxy issues.
