### PR TITLE
Supports multiple release channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,35 @@ customers:
 	@replicated customer create --channel Stable --snapshot --name Gulgow
 	@replicated customer create --channel Beta --expires-in 730h --name Vandervort
 	@replicated customer create --channel Stable --snapshot --expires-in 26300h --name Langworth
+
+stable:
+	@nerdctl pull registry.shortrib.dev/online-boutique/adservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/adservice:edge registry.shortrib.dev/online-boutique/adservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/adservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/cartservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/cartservice:edge registry.shortrib.dev/online-boutique/cartservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/cartservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/checkoutservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/checkoutservice:edge registry.shortrib.dev/online-boutique/checkoutservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/checkoutservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/currencyservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/currencyservice:edge registry.shortrib.dev/online-boutique/currencyservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/currencyservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/emailservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/emailservice:edge registry.shortrib.dev/online-boutique/emailservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/emailservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/frontend:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/frontend:edge registry.shortrib.dev/online-boutique/frontend:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/frontend:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/paymentservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/paymentservice:edge registry.shortrib.dev/online-boutique/paymentservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/paymentservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/productcatalogservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/productcatalogservice:edge registry.shortrib.dev/online-boutique/productcatalogservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/productcatalogservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/recommendationservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/recommendationservice:edge registry.shortrib.dev/online-boutique/recommendationservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/recommendationservice:stable
+	@nerdctl pull registry.shortrib.dev/online-boutique/shippingservice:edge \
+		&& nerdctl tag registry.shortrib.dev/online-boutique/shippingservice:edge registry.shortrib.dev/online-boutique/shippingservice:stable \
+		&& nerdctl push registry.shortrib.dev/online-boutique/shippingservice:stable

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,47 @@ endif
 install:
 	@kubectl kots install ${REPLICATED_APP}/$(CHANNEL)
 
+beta:
+	@fly --target boutique trigger-job --job release/promote-beta
+
+edge:
+	@fly --target boutique trigger-job --job release/promote-edge
+
+stable:
+	@fly --target boutique trigger-job --job release/promote-stable
+
+services: adservice cartservice checkoutservice currencyservice emailservice frontend paymentservice productcatalogservice recommendationservice shippingservice
+
+adservice:
+	@fly --target boutique trigger-job --job adservice/build
+
+cartservice:
+	@fly --target boutique trigger-job --job cartservice/build
+
+checkoutservice:
+	@fly --target boutique trigger-job --job checkoutservice/build
+
+currencyservice:
+	@fly --target boutique trigger-job --job currencyservice/build
+
+emailservice:
+	@fly --target boutique trigger-job --job emailservice/build
+
+frontend:
+	@fly --target boutique trigger-job --job frontend/build
+
+paymentservice:
+	@fly --target boutique trigger-job --job paymentservice/build
+
+productcatalogservice:
+	@fly --target boutique trigger-job --job productcatalogservice/build
+
+recommendationservice:
+	@fly --target boutique trigger-job --job recommendationservice/build
+
+shippingservice:
+	@fly --target boutique trigger-job --job shippingservice/build
+
 pipelines:
 	@fly --target boutique set-pipeline --pipeline adservice --config ci/concourse/adservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline adservice
 	@fly --target boutique set-pipeline --pipeline cartservice --config ci/concourse/cartservice/pipeline.yaml --non-interactive && fly -t boutique unpause-pipeline --pipeline cartservice
@@ -67,35 +108,3 @@ customers:
 	@replicated customer create --channel Stable --snapshot --name Gulgow
 	@replicated customer create --channel Beta --expires-in 730h --name Vandervort
 	@replicated customer create --channel Stable --snapshot --expires-in 26300h --name Langworth
-
-stable:
-	@nerdctl pull registry.shortrib.dev/online-boutique/adservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/adservice:edge registry.shortrib.dev/online-boutique/adservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/adservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/cartservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/cartservice:edge registry.shortrib.dev/online-boutique/cartservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/cartservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/checkoutservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/checkoutservice:edge registry.shortrib.dev/online-boutique/checkoutservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/checkoutservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/currencyservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/currencyservice:edge registry.shortrib.dev/online-boutique/currencyservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/currencyservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/emailservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/emailservice:edge registry.shortrib.dev/online-boutique/emailservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/emailservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/frontend:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/frontend:edge registry.shortrib.dev/online-boutique/frontend:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/frontend:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/paymentservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/paymentservice:edge registry.shortrib.dev/online-boutique/paymentservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/paymentservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/productcatalogservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/productcatalogservice:edge registry.shortrib.dev/online-boutique/productcatalogservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/productcatalogservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/recommendationservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/recommendationservice:edge registry.shortrib.dev/online-boutique/recommendationservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/recommendationservice:stable
-	@nerdctl pull registry.shortrib.dev/online-boutique/shippingservice:edge \
-		&& nerdctl tag registry.shortrib.dev/online-boutique/shippingservice:edge registry.shortrib.dev/online-boutique/shippingservice:stable \
-		&& nerdctl push registry.shortrib.dev/online-boutique/shippingservice:stable

--- a/ci/concourse/adservice/pipeline.yaml
+++ b/ci/concourse/adservice/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/adservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -52,6 +59,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -73,7 +85,12 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
-  
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
+
 - name: sign
   plan:
   - get: image

--- a/ci/concourse/cartservice/pipeline.yaml
+++ b/ci/concourse/cartservice/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/cartservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -45,6 +52,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -66,6 +78,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/checkoutservice/pipeline.yaml
+++ b/ci/concourse/checkoutservice/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/checkoutservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -44,6 +51,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -65,6 +77,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/currencyservice/pipeline.yaml
+++ b/ci/concourse/currencyservice/pipeline.yaml
@@ -13,13 +13,25 @@ resources:
     repository: registry.shortrib.dev/online-boutique/currencyservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: build
   plan:
   - get: source
     trigger: true
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -41,6 +53,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/emailservice/pipeline.yaml
+++ b/ci/concourse/emailservice/pipeline.yaml
@@ -13,13 +13,25 @@ resources:
     repository: registry.shortrib.dev/online-boutique/emailservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: build
   plan:
   - get: source
     trigger: true
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -41,6 +53,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/frontend/pipeline.yaml
+++ b/ci/concourse/frontend/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/frontend
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -44,6 +51,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -65,6 +77,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/paymentservice/pipeline.yaml
+++ b/ci/concourse/paymentservice/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/crdant/microservices-demo.git
+    uri: https://github.com/GoogleCloudPlatform/microservices-demo.git
     paths: 
     - src/paymentservice/**
 - name: image
@@ -13,13 +13,25 @@ resources:
     repository: registry.shortrib.dev/online-boutique/paymentservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: build
   plan:
   - get: source
     trigger: true
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -41,6 +53,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/productcatalogservice/pipeline.yaml
+++ b/ci/concourse/productcatalogservice/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/productcatalogservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -44,6 +51,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -65,6 +77,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/recommendationservice/pipeline.yaml
+++ b/ci/concourse/recommendationservice/pipeline.yaml
@@ -13,13 +13,25 @@ resources:
     repository: registry.shortrib.dev/online-boutique/recommendationservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: build
   plan:
   - get: source
     trigger: true
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -41,6 +53,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -11,6 +11,39 @@ git_credentials: &git_credentials
   password: ((github.password))
   signingkey: ((github.signing_priv_key))
 
+get_edge_images: &get_edge_images
+  steps:
+  - get: adservice-edge
+    passed:
+    - bump-patch-version
+  - get: cartservice-edge
+    passed:
+    - bump-patch-version
+  - get: checkoutservice-edge
+    passed:
+    - bump-patch-version
+  - get: currencyservice-edge
+    passed:
+    - bump-patch-version
+  - get: emailservice-edge
+    passed:
+    - bump-patch-version
+  - get: frontend-edge
+    passed:
+    - bump-patch-version
+  - get: paymentservice-edge
+    passed:
+    - bump-patch-version
+  - get: productcatalogservice-edge
+    passed:
+    - bump-patch-version
+  - get: recommendationservice-edge
+    passed:
+    - bump-patch-version
+  - get: shippingservice-edge
+    passed:
+    - bump-patch-version
+
 cosign_verify: &cosign_verify
   platform: linux
   image_resource:
@@ -37,38 +70,70 @@ cosign_verify: &cosign_verify
         /ko-app/cosign version 
         /ko-app/cosign verify --key k8s://concourse-online-boutique/signing-key $REPOSITORY@$DIGEST 
 
-get_images: &get_images
-  steps:
-  - get: adservice  
-    passed:
-    - bump-version
-  - get: cartservice  
-    passed:
-    - bump-version
-  - get: checkoutservice  
-    passed:
-    - bump-version
-  - get: currencyservice  
-    passed:
-    - bump-version
-  - get: emailservice  
-    passed:
-    - bump-version
-  - get: frontend  
-    passed:
-    - bump-version
-  - get: paymentservice  
-    passed:
-    - bump-version
-  - get: productcatalogservice  
-    passed:
-    - bump-version
-  - get: recommendationservice  
-    passed:
-    - bump-version
-  - get: shippingservice  
-    passed:
-    - bump-version
+prepare_release: &prepare_release
+  platform: linux
+  image_resource:
+    source:
+      repository: nixery.dev/shell/openssh/git/yq-go
+      tag: latest
+    type: registry-image
+  inputs:
+  - name: source
+  - name: adservice
+  - name: cartservice
+  - name: checkoutservice
+  - name: currencyservice
+  - name: emailservice
+  - name: frontend
+  - name: paymentservice
+  - name: productcatalogservice
+  - name: recommendationservice
+  - name: shippingservice
+  outputs:
+  - name: source
+  run:
+    user: root
+    path: bash
+    args:
+      - -c 
+      - |
+        export SSH_KEY_DIR=$(pwd)/ssh
+
+        function update_image_hash() {
+          service=${1}
+          digest=$(cat ${service}/digest)
+          yq -i ".spec.values.images.tag = \"edge@${digest}\"" source/manifests/${service}-chart.yaml
+        }
+
+        umask 077
+        mkdir $SSH_KEY_DIR
+        echo '((github.signing_priv_key))' >> ${SSH_KEY_DIR}/signingkey
+        
+        # this is a hack for now to get past an error, will likely need to switch
+        # from the nixery image and build one with a passwd file in order to use SSH
+        # to sign the commit
+        echo 'root:*:0:0:System Administrator:/var/root:/bin/sh' > /etc/passwd
+
+        update_image_hash adservice
+        update_image_hash cartservice
+        update_image_hash checkoutservice
+        update_image_hash currencyservice
+        update_image_hash emailservice
+        update_image_hash frontend
+        update_image_hash paymentservice
+        update_image_hash productcatalogservice
+        update_image_hash recommendationservice
+        update_image_hash shippingservice
+
+        cd next-release 
+        git config --global user.name "Online Boutique Release Pipeline"
+        git config --global user.email "chuck@replicated.com"
+        git config --global user.signingkey ${SSH_KEY_DIR}/signingkey
+        git config --global gpg.format ssh 
+        git config --global commit.gpgsign true 
+
+        git add manifests/*-chart.yaml
+        git commit -m "Updates adservice digest to ${DIGEST}"
 
 resources:
 - name: current-release
@@ -167,6 +232,76 @@ resources:
     repository: registry.shortrib.dev/online-boutique/shippingservice
     tag: edge
     <<: *registry_credentials
+- name: adservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/adservice
+    tag: stable
+    <<: *registry_credentials
+- name: cartservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/cartservice
+    tag: stable
+    <<: *registry_credentials
+- name: checkoutservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/checkoutservice
+    tag: stable
+    <<: *registry_credentials
+- name: currencyservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/currencyservice
+    tag: stable
+    <<: *registry_credentials
+- name: emailservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/emailservice
+    tag: stable
+    <<: *registry_credentials
+- name: frontend-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/frontend
+    tag: stable
+    <<: *registry_credentials
+- name: paymentservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/paymentservice
+    tag: stable
+    <<: *registry_credentials
+- name: productcatalogservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/productcatalogservice
+    tag: stable
+    <<: *registry_credentials
+- name: recommendationservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/recommendationservice
+    tag: stable
+    <<: *registry_credentials
+- name: shippingservice-stable
+  type: registry-image
+  icon: oci 
+  source:
+    repository: registry.shortrib.dev/online-boutique/shippingservice
+    tag: stable
+    <<: *registry_credentials
 
 jobs:
 - name: verify-adservice-edge
@@ -175,7 +310,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: adservice
+      image: adservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -187,7 +322,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: cartservice
+      image: cartservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -199,7 +334,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: checkoutservice
+      image: checkoutservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -211,7 +346,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: currencyservice
+      image: currencyservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -223,7 +358,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: emailservice
+      image: emailservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -247,7 +382,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: paymentservice
+      image: paymentservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -259,7 +394,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: productcatalogservice
+      image: productcatalogservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -271,7 +406,7 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: recommendationservice
+      image: recommendationservice-edge
     params:
       <<: *cosign_credentials
     config:
@@ -283,13 +418,13 @@ jobs:
     trigger: true
   - task: verify
     input_mapping:
-      image: shippingservice
+      image: shippingservice-edge
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: bump-version
+- name: bump-patch-version
   plan:
   - get: current-release
   - get: next-release
@@ -345,11 +480,11 @@ jobs:
   - get: version
     trigger: true
     passed:
-    - bump-version
+    - bump-patch-version
   - load_var: version
     file: version/version
   - in_parallel:
-      <<: *get_images
+      <<: *get_edge_images
   - task:  deploy
     params:
       KUBECONFIG_JSON: ((saas.kubeconfig))
@@ -433,21 +568,31 @@ jobs:
               --set loadGenerator.create=false \
               --post-renderer $(pwd)/kustomize.sh
 
-- name: prepare-replicated
+- name: prepare-edge-release
   plan:
   - get: current-release
   - get: next-release
   - in_parallel:
-      <<: *get_images
+      <<: *get_edge_images
   - get: version
     trigger: true
     passed:
-    - bump-version
+    - bump-patch-version
   - load_var: version
     file: version/version
   - task: update-image-tags
     input_mapping:
       source: next-release
+      adservice: adservice-edge
+      cartservice: cartservice-edge
+      checkoutservice: checkoutservice-edge
+      currencyservice: currencyservice-edge
+      emailservice: emailservice-edge
+      frontend: frontend-edge
+      paymentservice: paymentservice-edge
+      productcatalogservice: productcatalogservice-edge
+      recommendationservice: recommendationservice-edge
+      shippingservice: shippingservice-edge
     output_mapping:
       source: next-release
     config:
@@ -545,15 +690,15 @@ jobs:
       repository: next-release
       branch: release-((.:version))
 
-- name: merge-replicated
+- name: merge-edge-release
   plan:
   - get: next-release
     trigger: true
     passed:
-    - prepare-replicated
+    - prepare-edge-release
   - get: version
     passed:
-    - prepare-replicated
+    - prepare-edge-release
   - load_var: version
     file: version/version
   - task: create-pull-request
@@ -617,15 +762,15 @@ jobs:
             gh auth login -h github.com
             gh pr merge --merge --match-head-commit $(cat next-release/.git/ref) ${PR_URL}
 
-- name: release-replicated
+- name: release-edge
   plan:
   - get: next-release
     trigger: true
     passed:
-    - merge-replicated
+    - merge-edge-release
   - get: version
     passed:
-    - merge-replicated
+    - merge-edge-release
   - load_var: version
     file: version/version
   - task: release-app
@@ -659,3 +804,348 @@ jobs:
               --yaml-dir manifests \
               --ensure-channel \
               --promote edge
+
+- name: verify-adservice-stable
+  plan:
+  - get: adservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: adservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-cartservice-stable
+  plan:
+  - get: cartservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: cartservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-checkoutservice-stable
+  plan:
+  - get: checkoutservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: checkoutservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-currencyservice-stable
+  plan:
+  - get: currencyservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: currencyservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-emailservice-stable
+  plan:
+  - get: emailservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: emailservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-frontend-stable
+  plan:
+  - get: frontend-stable
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: frontend-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-paymentservice-stable
+  plan:
+  - get: paymentservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: paymentservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-productcatalogservice-stable
+  plan:
+  - get: productcatalogservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: productcatalogservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-recommendationservice-stable
+  plan:
+  - get: recommendationservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: recommendationservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+- name: verify-shippingservice-stable
+  plan:
+  - get: shippingservice-stable  
+    trigger: true
+  - task: verify
+    input_mapping:
+      image: shippingservice-stable
+    params:
+      <<: *cosign_credentials
+    config:
+      <<: *cosign_verify
+
+
+- name: bump-minor-version
+  plan:
+  - get: current-release
+  - get: next-release
+  - get: adservice-stable  
+    trigger: true
+    passed:
+    - verify-adservice-stable
+  - get: cartservice-stable  
+    trigger: true
+    passed:
+    - verify-cartservice-stable
+  - get: checkoutservice-stable  
+    trigger: true
+    passed:
+    - verify-checkoutservice-stable
+  - get: currencyservice-stable  
+    trigger: true
+    passed:
+    - verify-currencyservice-stable
+  - get: emailservice-stable  
+    trigger: true
+    passed:
+    - verify-emailservice-stable
+  - get: frontend-stable
+    trigger: true
+    passed:
+    - verify-frontend-stable
+  - get: paymentservice-stable  
+    trigger: true
+    passed:
+    - verify-paymentservice-stable
+  - get: productcatalogservice-stable  
+    trigger: true
+    passed:
+    - verify-productcatalogservice-stable
+  - get: recommendationservice-stable  
+    trigger: true
+    passed:
+    - verify-recommendationservice-stable
+  - get: shippingservice-stable  
+    trigger: true
+    passed:
+    - verify-shippingservice-stable
+  - get: version
+    params:
+      bump: minor
+  - put: version
+    params:
+      file: version/version
+
+- name: prepare-stable-release
+  plan:
+  - get: current-release
+  - get: next-release
+  - get: adservice-stable
+    passed:
+    - bump-minor-version
+  - get: cartservice-stable
+    passed:
+    - bump-minor-version
+  - get: checkoutservice-stable
+    passed:
+    - bump-minor-version
+  - get: currencyservice-stable
+    passed:
+    - bump-minor-version
+  - get: emailservice-stable
+    passed:
+    - bump-minor-version
+  - get: frontend-stable
+    passed:
+    - bump-minor-version
+  - get: paymentservice-stable
+    passed:
+    - bump-minor-version
+  - get: productcatalogservice-stable
+    passed:
+    - bump-minor-version
+  - get: recommendationservice-stable
+    passed:
+    - bump-minor-version
+  - get: shippingservice-stable
+    passed:
+    - bump-minor-version
+  - get: version
+    trigger: true
+    passed:
+    - bump-minor-version
+  - load_var: version
+    file: version/version
+  - task: update-image-tags
+    input_mapping:
+      source: next-release
+      adservice: adservice-stable
+      cartservice: cartservice-stable
+      checkoutservice: checkoutservice-stable
+      currencyservice: currencyservice-stable
+      emailservice: emailservice-stable
+      frontend: frontend-stable
+      paymentservice: paymentservice-stable
+      productcatalogservice: productcatalogservice-stable
+      recommendationservice: recommendationservice-stable
+      shippingservice: shippingservice-stable
+    output_mapping:
+      source: next-release
+    config:
+      <<: *prepare_release
+  - put: next-release
+    params:
+      repository: next-release
+      branch: release-((.:version))
+
+- name: merge-stable-release
+  plan:
+  - get: next-release
+    trigger: true
+    passed:
+    - prepare-stable-release
+  - get: version
+    passed:
+    - prepare-stable-release
+  - load_var: version
+    file: version/version
+  - task: create-pull-request
+    params:
+      GITHUB_TOKEN: ((github.password))
+      RELEASE_BRANCH: release-((.:version))
+      PR_BODY: |
+        Automatic update of application manifests in response to updates to
+        the Ad Service image.
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: nixery.dev/shell/git/gh
+          tag: latest
+        type: registry-image
+      inputs:
+      - name: next-release
+      outputs:
+      - name: pr
+      run:
+        user: root
+        path: bash
+        args:
+          - -c 
+          - |
+            OUTPUT_DIR=$(pwd)/pr
+
+            cd next-release
+            gh auth login -h github.com
+            gh pr create --head ${RELEASE_BRANCH} \
+                --title "Bumps Ad Service to latest image" \
+                --body "${PR_BODY}" \
+              > ${OUTPUT_DIR}/url
+  - task: merge-pull-request
+    params:
+      GITHUB_TOKEN: ((github.password))
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: nixery.dev/shell/git/gh
+          tag: latest
+        type: registry-image
+      inputs:
+      - name: next-release
+      - name: pr
+      run:
+        user: root
+        path: bash
+        args:
+          - -c 
+          - |
+            PR_URL=$(cat pr/url)
+
+            set -x
+            gh auth login -h github.com
+            gh pr merge --merge --match-head-commit $(cat next-release/.git/ref) ${PR_URL}
+
+- name: release-stable
+  plan:
+  - get: next-release
+    trigger: true
+    passed:
+    - merge-stable-release
+  - get: version
+    passed:
+    - merge-stable-release
+  - load_var: version
+    file: version/version
+  - task: release-app
+    params:
+      REPLICATED_APP: online-boutique
+      REPLICATED_API_TOKEN: ((replicated.token))
+      VERSION: ((.:version))
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: replicated/vendor-cli
+          tag: latest
+        type: registry-image
+      inputs:
+      - name: next-release
+      run:
+        user: root
+        path: sh
+        dir: next-release
+        args:
+          - -c 
+          - |
+            RELEASE_NOTES="$(cat .git/commit_message)"
+    
+            /replicated release create \
+              --app ${REPLICATED_APP} \
+              --token ${REPLICATED_API_TOKEN} \
+              --version ${VERSION} \
+              --release-notes "${RELEASE_NOTES}" \
+              --yaml-dir manifests \
+              --ensure-channel \
+              --promote Stable

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -445,17 +445,17 @@ jobs:
           tag: latest
         type: registry-image
       inputs:
-      - name: source
-      - name: adservice-edge
-      - name: cartservice-edge
-      - name: checkoutservice-edge
-      - name: currencyservice-edge
-      - name: emailservice-edge
-      - name: frontend-edge
-      - name: paymentservice-edge
-      - name: productcatalogservice-edge
-      - name: recommendationservice-edge
-      - name: shippingservice-edge
+      - name: next-release
+      - name: adservice
+      - name: cartservice
+      - name: checkoutservice
+      - name: currencyservice
+      - name: emailservice
+      - name: frontend
+      - name: paymentservice
+      - name: productcatalogservice
+      - name: recommendationservice
+      - name: shippingservice
       outputs:
       - name: next-release
       run:

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -97,70 +97,70 @@ resources:
     branch: version
     file: version
     <<: *git_credentials
-- name: adservice
+- name: adservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/adservice
     tag: edge
     <<: *registry_credentials
-- name: cartservice
+- name: cartservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/cartservice
     tag: edge
     <<: *registry_credentials
-- name: checkoutservice
+- name: checkoutservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/checkoutservice
     tag: edge
     <<: *registry_credentials
-- name: currencyservice
+- name: currencyservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/currencyservice
     tag: edge
     <<: *registry_credentials
-- name: emailservice
+- name: emailservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/emailservice
     tag: edge
     <<: *registry_credentials
-- name: frontend
+- name: frontend-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/frontend
     tag: edge
     <<: *registry_credentials
-- name: paymentservice
+- name: paymentservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/paymentservice
     tag: edge
     <<: *registry_credentials
-- name: productcatalogservice
+- name: productcatalogservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/productcatalogservice
     tag: edge
     <<: *registry_credentials
-- name: recommendationservice
+- name: recommendationservice-edge
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/recommendationservice
     tag: edge
     <<: *registry_credentials
-- name: shippingservice
+- name: shippingservice-edge
   type: registry-image
   icon: oci 
   source:
@@ -169,9 +169,9 @@ resources:
     <<: *registry_credentials
 
 jobs:
-- name: verify-adservice
+- name: verify-adservice-edge
   plan:
-  - get: adservice  
+  - get: adservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -181,9 +181,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-cartservice
+- name: verify-cartservice-edge
   plan:
-  - get: cartservice  
+  - get: cartservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -193,9 +193,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-checkoutservice
+- name: verify-checkoutservice-edge
   plan:
-  - get: checkoutservice  
+  - get: checkoutservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -205,9 +205,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-currencyservice
+- name: verify-currencyservice-edge
   plan:
-  - get: currencyservice  
+  - get: currencyservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -217,9 +217,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-emailservice
+- name: verify-emailservice-edge
   plan:
-  - get: emailservice  
+  - get: emailservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -229,21 +229,21 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-frontend
+- name: verify-frontend-edge
   plan:
-  - get: frontend  
+  - get: frontend-edge
     trigger: true
   - task: verify
     input_mapping:
-      image: frontend
+      image: frontend-edge
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-paymentservice
+- name: verify-paymentservice-edge
   plan:
-  - get: paymentservice  
+  - get: paymentservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -253,9 +253,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-productcatalogservice
+- name: verify-productcatalogservice-edge
   plan:
-  - get: productcatalogservice  
+  - get: productcatalogservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -265,9 +265,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-recommendationservice
+- name: verify-recommendationservice-edge
   plan:
-  - get: recommendationservice  
+  - get: recommendationservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -277,9 +277,9 @@ jobs:
     config:
       <<: *cosign_verify
 
-- name: verify-shippingservice
+- name: verify-shippingservice-edge
   plan:
-  - get: shippingservice  
+  - get: shippingservice-edge  
     trigger: true
   - task: verify
     input_mapping:
@@ -291,46 +291,48 @@ jobs:
 
 - name: bump-version
   plan:
-  - get: adservice  
+  - get: current-release
+  - get: next-release
+  - get: adservice-edge  
     trigger: true
     passed:
-    - verify-adservice
-  - get: cartservice  
+    - verify-adservice-edge
+  - get: cartservice-edge  
     trigger: true
     passed:
-    - verify-cartservice
-  - get: checkoutservice  
+    - verify-cartservice-edge
+  - get: checkoutservice-edge  
     trigger: true
     passed:
-    - verify-checkoutservice
-  - get: currencyservice  
+    - verify-checkoutservice-edge
+  - get: currencyservice-edge  
     trigger: true
     passed:
-    - verify-currencyservice
-  - get: emailservice  
+    - verify-currencyservice-edge
+  - get: emailservice-edge  
     trigger: true
     passed:
-    - verify-emailservice
-  - get: frontend  
+    - verify-emailservice-edge
+  - get: frontend-edge
     trigger: true
     passed:
-    - verify-frontend
-  - get: paymentservice  
+    - verify-frontend-edge
+  - get: paymentservice-edge  
     trigger: true
     passed:
-    - verify-paymentservice
-  - get: productcatalogservice  
+    - verify-paymentservice-edge
+  - get: productcatalogservice-edge  
     trigger: true
     passed:
-    - verify-productcatalogservice
-  - get: recommendationservice  
+    - verify-productcatalogservice-edge
+  - get: recommendationservice-edge  
     trigger: true
     passed:
-    - verify-recommendationservice
-  - get: shippingservice  
+    - verify-recommendationservice-edge
+  - get: shippingservice-edge  
     trigger: true
     passed:
-    - verify-shippingservice
+    - verify-shippingservice-edge
   - get: version
     params:
       bump: patch
@@ -444,6 +446,10 @@ jobs:
   - load_var: version
     file: version/version
   - task: update-image-tags
+    input_mapping:
+      source: next-release
+    output_mapping:
+      source: next-release
     config:
       platform: linux
       image_resource:
@@ -452,17 +458,17 @@ jobs:
           tag: latest
         type: registry-image
       inputs:
-      - name: next-release
-      - name: adservice
-      - name: cartservice
-      - name: checkoutservice
-      - name: currencyservice
-      - name: emailservice
-      - name: frontend
-      - name: paymentservice
-      - name: productcatalogservice
-      - name: recommendationservice
-      - name: shippingservice
+      - name: source
+      - name: adservice-edge
+      - name: cartservice-edge
+      - name: checkoutservice-edge
+      - name: currencyservice-edge
+      - name: emailservice-edge
+      - name: frontend-edge
+      - name: paymentservice-edge
+      - name: productcatalogservice-edge
+      - name: recommendationservice-edge
+      - name: shippingservice-edge
       outputs:
       - name: next-release
       run:

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -405,7 +405,6 @@ jobs:
 
             helm version
             kustomize version
-            kubectl get all -n online-boutique
 
             kustomize_service adservice
             kustomize_service cartservice
@@ -419,6 +418,7 @@ jobs:
             kustomize_service shippingservice
 
             helm upgrade uncommon-starfish oci://registry.shortrib.dev/online-boutique/onlineboutique \
+              --namespace online-boutique \
               --install --version 0.6.0 \
               --set images.repository=registry.shortrib.dev/online-boutique \
               --set loadGenerator.create=false \
@@ -479,6 +479,7 @@ jobs:
             -------
 
             Updates images versions for the following services: 
+
             COMMIT_MESSAGE
 
             function update_image_hash() {

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -11,39 +11,6 @@ git_credentials: &git_credentials
   password: ((github.password))
   signingkey: ((github.signing_priv_key))
 
-get_edge_images: &get_edge_images
-  steps:
-  - get: adservice-edge
-    passed:
-    - bump-patch-version
-  - get: cartservice-edge
-    passed:
-    - bump-patch-version
-  - get: checkoutservice-edge
-    passed:
-    - bump-patch-version
-  - get: currencyservice-edge
-    passed:
-    - bump-patch-version
-  - get: emailservice-edge
-    passed:
-    - bump-patch-version
-  - get: frontend-edge
-    passed:
-    - bump-patch-version
-  - get: paymentservice-edge
-    passed:
-    - bump-patch-version
-  - get: productcatalogservice-edge
-    passed:
-    - bump-patch-version
-  - get: recommendationservice-edge
-    passed:
-    - bump-patch-version
-  - get: shippingservice-edge
-    passed:
-    - bump-patch-version
-
 cosign_verify: &cosign_verify
   platform: linux
   image_resource:
@@ -58,6 +25,10 @@ cosign_verify: &cosign_verify
     args:
       - -c
       - |
+        # HACK! we need to pause a bit becaues there's a gap between when the image is pushed
+        # and when it's signed
+        sleep 80
+
         umask 077
         mkdir ${HOME}/.kube
         echo "$KUBECONFIG_JSON" > ${HOME}/.kube/config
@@ -70,70 +41,38 @@ cosign_verify: &cosign_verify
         /ko-app/cosign version 
         /ko-app/cosign verify --key k8s://concourse-online-boutique/signing-key $REPOSITORY@$DIGEST 
 
-prepare_release: &prepare_release
-  platform: linux
-  image_resource:
-    source:
-      repository: nixery.dev/shell/openssh/git/yq-go
-      tag: latest
-    type: registry-image
-  inputs:
-  - name: source
-  - name: adservice
-  - name: cartservice
-  - name: checkoutservice
-  - name: currencyservice
-  - name: emailservice
-  - name: frontend
-  - name: paymentservice
-  - name: productcatalogservice
-  - name: recommendationservice
-  - name: shippingservice
-  outputs:
-  - name: source
-  run:
-    user: root
-    path: bash
-    args:
-      - -c 
-      - |
-        export SSH_KEY_DIR=$(pwd)/ssh
-
-        function update_image_hash() {
-          service=${1}
-          digest=$(cat ${service}/digest)
-          yq -i ".spec.values.images.tag = \"edge@${digest}\"" source/manifests/${service}-chart.yaml
-        }
-
-        umask 077
-        mkdir $SSH_KEY_DIR
-        echo '((github.signing_priv_key))' >> ${SSH_KEY_DIR}/signingkey
-        
-        # this is a hack for now to get past an error, will likely need to switch
-        # from the nixery image and build one with a passwd file in order to use SSH
-        # to sign the commit
-        echo 'root:*:0:0:System Administrator:/var/root:/bin/sh' > /etc/passwd
-
-        update_image_hash adservice
-        update_image_hash cartservice
-        update_image_hash checkoutservice
-        update_image_hash currencyservice
-        update_image_hash emailservice
-        update_image_hash frontend
-        update_image_hash paymentservice
-        update_image_hash productcatalogservice
-        update_image_hash recommendationservice
-        update_image_hash shippingservice
-
-        cd next-release 
-        git config --global user.name "Online Boutique Release Pipeline"
-        git config --global user.email "chuck@replicated.com"
-        git config --global user.signingkey ${SSH_KEY_DIR}/signingkey
-        git config --global gpg.format ssh 
-        git config --global commit.gpgsign true 
-
-        git add manifests/*-chart.yaml
-        git commit -m "Updates adservice digest to ${DIGEST}"
+get_images: &get_images
+  steps:
+  - get: adservice  
+    passed:
+    - bump-patch-version
+  - get: cartservice  
+    passed:
+    - bump-patch-version
+  - get: checkoutservice  
+    passed:
+    - bump-patch-version
+  - get: currencyservice  
+    passed:
+    - bump-patch-version
+  - get: emailservice  
+    passed:
+    - bump-patch-version
+  - get: frontend  
+    passed:
+    - bump-patch-version
+  - get: paymentservice  
+    passed:
+    - bump-patch-version
+  - get: productcatalogservice  
+    passed:
+    - bump-patch-version
+  - get: recommendationservice  
+    passed:
+    - bump-patch-version
+  - get: shippingservice  
+    passed:
+    - bump-patch-version
 
 resources:
 - name: current-release
@@ -157,268 +96,187 @@ resources:
   type: semver
   icon: counter
   source:
-    driver: git
-    uri: https://github.com/crdant/online-boutique-replicated.git
-    branch: version
-    file: version
-    <<: *git_credentials
-- name: adservice-edge
+    driver: gcs
+    bucket: online-boutique-semver
+    key: replicated-version
+    json_key: ((gcs.serviceaccountjson))
+- name: adservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/adservice
-    tag: edge
     <<: *registry_credentials
-- name: cartservice-edge
+- name: cartservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/cartservice
-    tag: edge
     <<: *registry_credentials
-- name: checkoutservice-edge
+- name: checkoutservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/checkoutservice
-    tag: edge
     <<: *registry_credentials
-- name: currencyservice-edge
+- name: currencyservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/currencyservice
-    tag: edge
     <<: *registry_credentials
-- name: emailservice-edge
+- name: emailservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/emailservice
-    tag: edge
     <<: *registry_credentials
-- name: frontend-edge
+- name: frontend
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/frontend
-    tag: edge
     <<: *registry_credentials
-- name: paymentservice-edge
+- name: paymentservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/paymentservice
-    tag: edge
     <<: *registry_credentials
-- name: productcatalogservice-edge
+- name: productcatalogservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/productcatalogservice
-    tag: edge
     <<: *registry_credentials
-- name: recommendationservice-edge
+- name: recommendationservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/recommendationservice
-    tag: edge
     <<: *registry_credentials
-- name: shippingservice-edge
+- name: shippingservice
   type: registry-image
   icon: oci 
   source:
     repository: registry.shortrib.dev/online-boutique/shippingservice
-    tag: edge
-    <<: *registry_credentials
-- name: adservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/adservice
-    tag: stable
-    <<: *registry_credentials
-- name: cartservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/cartservice
-    tag: stable
-    <<: *registry_credentials
-- name: checkoutservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/checkoutservice
-    tag: stable
-    <<: *registry_credentials
-- name: currencyservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/currencyservice
-    tag: stable
-    <<: *registry_credentials
-- name: emailservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/emailservice
-    tag: stable
-    <<: *registry_credentials
-- name: frontend-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/frontend
-    tag: stable
-    <<: *registry_credentials
-- name: paymentservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/paymentservice
-    tag: stable
-    <<: *registry_credentials
-- name: productcatalogservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/productcatalogservice
-    tag: stable
-    <<: *registry_credentials
-- name: recommendationservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/recommendationservice
-    tag: stable
-    <<: *registry_credentials
-- name: shippingservice-stable
-  type: registry-image
-  icon: oci 
-  source:
-    repository: registry.shortrib.dev/online-boutique/shippingservice
-    tag: stable
     <<: *registry_credentials
 
 jobs:
-- name: verify-adservice-edge
+- name: verify-adservice
   plan:
-  - get: adservice-edge  
+  - get: adservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: adservice-edge
+      image: adservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-cartservice-edge
+- name: verify-cartservice
   plan:
-  - get: cartservice-edge  
+  - get: cartservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: cartservice-edge
+      image: cartservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-checkoutservice-edge
+- name: verify-checkoutservice
   plan:
-  - get: checkoutservice-edge  
+  - get: checkoutservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: checkoutservice-edge
+      image: checkoutservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-currencyservice-edge
+- name: verify-currencyservice
   plan:
-  - get: currencyservice-edge  
+  - get: currencyservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: currencyservice-edge
+      image: currencyservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-emailservice-edge
+- name: verify-emailservice
   plan:
-  - get: emailservice-edge  
+  - get: emailservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: emailservice-edge
+      image: emailservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-frontend-edge
+- name: verify-frontend
   plan:
-  - get: frontend-edge
+  - get: frontend  
     trigger: true
   - task: verify
     input_mapping:
-      image: frontend-edge
+      image: frontend
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-paymentservice-edge
+- name: verify-paymentservice
   plan:
-  - get: paymentservice-edge  
+  - get: paymentservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: paymentservice-edge
+      image: paymentservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-productcatalogservice-edge
+- name: verify-productcatalogservice
   plan:
-  - get: productcatalogservice-edge  
+  - get: productcatalogservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: productcatalogservice-edge
+      image: productcatalogservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-recommendationservice-edge
+- name: verify-recommendationservice
   plan:
-  - get: recommendationservice-edge  
+  - get: recommendationservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: recommendationservice-edge
+      image: recommendationservice
     params:
       <<: *cosign_credentials
     config:
       <<: *cosign_verify
 
-- name: verify-shippingservice-edge
+- name: verify-shippingservice
   plan:
-  - get: shippingservice-edge  
+  - get: shippingservice  
     trigger: true
   - task: verify
     input_mapping:
-      image: shippingservice-edge
+      image: shippingservice
     params:
       <<: *cosign_credentials
     config:
@@ -426,48 +284,46 @@ jobs:
 
 - name: bump-patch-version
   plan:
-  - get: current-release
-  - get: next-release
-  - get: adservice-edge  
+  - get: adservice  
     trigger: true
     passed:
-    - verify-adservice-edge
-  - get: cartservice-edge  
+    - verify-adservice
+  - get: cartservice  
     trigger: true
     passed:
-    - verify-cartservice-edge
-  - get: checkoutservice-edge  
+    - verify-cartservice
+  - get: checkoutservice  
     trigger: true
     passed:
-    - verify-checkoutservice-edge
-  - get: currencyservice-edge  
+    - verify-checkoutservice
+  - get: currencyservice  
     trigger: true
     passed:
-    - verify-currencyservice-edge
-  - get: emailservice-edge  
+    - verify-currencyservice
+  - get: emailservice  
     trigger: true
     passed:
-    - verify-emailservice-edge
-  - get: frontend-edge
+    - verify-emailservice
+  - get: frontend  
     trigger: true
     passed:
-    - verify-frontend-edge
-  - get: paymentservice-edge  
+    - verify-frontend
+  - get: paymentservice  
     trigger: true
     passed:
-    - verify-paymentservice-edge
-  - get: productcatalogservice-edge  
+    - verify-paymentservice
+  - get: productcatalogservice  
     trigger: true
     passed:
-    - verify-productcatalogservice-edge
-  - get: recommendationservice-edge  
+    - verify-productcatalogservice
+  - get: recommendationservice  
     trigger: true
     passed:
-    - verify-recommendationservice-edge
-  - get: shippingservice-edge  
+    - verify-recommendationservice
+  - get: shippingservice  
     trigger: true
     passed:
-    - verify-shippingservice-edge
+    - verify-shippingservice
   - get: version
     params:
       bump: patch
@@ -484,7 +340,7 @@ jobs:
   - load_var: version
     file: version/version
   - in_parallel:
-      <<: *get_edge_images
+      <<: *get_images
   - task:  deploy
     params:
       KUBECONFIG_JSON: ((saas.kubeconfig))
@@ -568,12 +424,12 @@ jobs:
               --set loadGenerator.create=false \
               --post-renderer $(pwd)/kustomize.sh
 
-- name: prepare-edge-release
+- name: prepare-replicated
   plan:
   - get: current-release
   - get: next-release
   - in_parallel:
-      <<: *get_edge_images
+      <<: *get_images
   - get: version
     trigger: true
     passed:
@@ -581,20 +437,6 @@ jobs:
   - load_var: version
     file: version/version
   - task: update-image-tags
-    input_mapping:
-      source: next-release
-      adservice: adservice-edge
-      cartservice: cartservice-edge
-      checkoutservice: checkoutservice-edge
-      currencyservice: currencyservice-edge
-      emailservice: emailservice-edge
-      frontend: frontend-edge
-      paymentservice: paymentservice-edge
-      productcatalogservice: productcatalogservice-edge
-      recommendationservice: recommendationservice-edge
-      shippingservice: shippingservice-edge
-    output_mapping:
-      source: next-release
     config:
       platform: linux
       image_resource:
@@ -642,6 +484,7 @@ jobs:
             function update_image_hash() {
               service=${1}
               digest=$(cat ${service}/digest)
+             
               # this is a little bit hacky because we may or may not be in the working tree
               manifest="manifests/${service}-chart.yaml"
 
@@ -690,15 +533,15 @@ jobs:
       repository: next-release
       branch: release-((.:version))
 
-- name: merge-edge-release
+- name: merge-replicated
   plan:
   - get: next-release
     trigger: true
     passed:
-    - prepare-edge-release
+    - prepare-replicated
   - get: version
     passed:
-    - prepare-edge-release
+    - prepare-replicated
   - load_var: version
     file: version/version
   - task: create-pull-request
@@ -762,15 +605,15 @@ jobs:
             gh auth login -h github.com
             gh pr merge --merge --match-head-commit $(cat next-release/.git/ref) ${PR_URL}
 
-- name: release-edge
+- name: release-unstable
   plan:
   - get: next-release
     trigger: true
     passed:
-    - merge-edge-release
+    - merge-replicated
   - get: version
     passed:
-    - merge-edge-release
+    - merge-replicated
   - load_var: version
     file: version/version
   - task: release-app
@@ -802,320 +645,16 @@ jobs:
               --version ${VERSION} \
               --release-notes "${RELEASE_NOTES}" \
               --yaml-dir manifests \
-              --ensure-channel \
-              --promote edge
+              --promote Unstable
 
-- name: verify-adservice-stable
-  plan:
-  - get: adservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: adservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-cartservice-stable
-  plan:
-  - get: cartservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: cartservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-checkoutservice-stable
-  plan:
-  - get: checkoutservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: checkoutservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-currencyservice-stable
-  plan:
-  - get: currencyservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: currencyservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-emailservice-stable
-  plan:
-  - get: emailservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: emailservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-frontend-stable
-  plan:
-  - get: frontend-stable
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: frontend-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-paymentservice-stable
-  plan:
-  - get: paymentservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: paymentservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-productcatalogservice-stable
-  plan:
-  - get: productcatalogservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: productcatalogservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-recommendationservice-stable
-  plan:
-  - get: recommendationservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: recommendationservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-- name: verify-shippingservice-stable
-  plan:
-  - get: shippingservice-stable  
-    trigger: true
-  - task: verify
-    input_mapping:
-      image: shippingservice-stable
-    params:
-      <<: *cosign_credentials
-    config:
-      <<: *cosign_verify
-
-
-- name: bump-minor-version
-  plan:
-  - get: current-release
-  - get: next-release
-  - get: adservice-stable  
-    trigger: true
-    passed:
-    - verify-adservice-stable
-  - get: cartservice-stable  
-    trigger: true
-    passed:
-    - verify-cartservice-stable
-  - get: checkoutservice-stable  
-    trigger: true
-    passed:
-    - verify-checkoutservice-stable
-  - get: currencyservice-stable  
-    trigger: true
-    passed:
-    - verify-currencyservice-stable
-  - get: emailservice-stable  
-    trigger: true
-    passed:
-    - verify-emailservice-stable
-  - get: frontend-stable
-    trigger: true
-    passed:
-    - verify-frontend-stable
-  - get: paymentservice-stable  
-    trigger: true
-    passed:
-    - verify-paymentservice-stable
-  - get: productcatalogservice-stable  
-    trigger: true
-    passed:
-    - verify-productcatalogservice-stable
-  - get: recommendationservice-stable  
-    trigger: true
-    passed:
-    - verify-recommendationservice-stable
-  - get: shippingservice-stable  
-    trigger: true
-    passed:
-    - verify-shippingservice-stable
-  - get: version
-    params:
-      bump: minor
-  - put: version
-    params:
-      file: version/version
-
-- name: prepare-stable-release
-  plan:
-  - get: current-release
-  - get: next-release
-  - get: adservice-stable
-    passed:
-    - bump-minor-version
-  - get: cartservice-stable
-    passed:
-    - bump-minor-version
-  - get: checkoutservice-stable
-    passed:
-    - bump-minor-version
-  - get: currencyservice-stable
-    passed:
-    - bump-minor-version
-  - get: emailservice-stable
-    passed:
-    - bump-minor-version
-  - get: frontend-stable
-    passed:
-    - bump-minor-version
-  - get: paymentservice-stable
-    passed:
-    - bump-minor-version
-  - get: productcatalogservice-stable
-    passed:
-    - bump-minor-version
-  - get: recommendationservice-stable
-    passed:
-    - bump-minor-version
-  - get: shippingservice-stable
-    passed:
-    - bump-minor-version
-  - get: version
-    trigger: true
-    passed:
-    - bump-minor-version
-  - load_var: version
-    file: version/version
-  - task: update-image-tags
-    input_mapping:
-      source: next-release
-      adservice: adservice-stable
-      cartservice: cartservice-stable
-      checkoutservice: checkoutservice-stable
-      currencyservice: currencyservice-stable
-      emailservice: emailservice-stable
-      frontend: frontend-stable
-      paymentservice: paymentservice-stable
-      productcatalogservice: productcatalogservice-stable
-      recommendationservice: recommendationservice-stable
-      shippingservice: shippingservice-stable
-    output_mapping:
-      source: next-release
-    config:
-      <<: *prepare_release
-  - put: next-release
-    params:
-      repository: next-release
-      branch: release-((.:version))
-
-- name: merge-stable-release
+- name: promote-beta
   plan:
   - get: next-release
-    trigger: true
     passed:
-    - prepare-stable-release
+    - release-unstable
   - get: version
     passed:
-    - prepare-stable-release
-  - load_var: version
-    file: version/version
-  - task: create-pull-request
-    params:
-      GITHUB_TOKEN: ((github.password))
-      RELEASE_BRANCH: release-((.:version))
-      PR_BODY: |
-        Automatic update of application manifests in response to updates to
-        the Ad Service image.
-    config:
-      platform: linux
-      image_resource:
-        source:
-          repository: nixery.dev/shell/git/gh
-          tag: latest
-        type: registry-image
-      inputs:
-      - name: next-release
-      outputs:
-      - name: pr
-      run:
-        user: root
-        path: bash
-        args:
-          - -c 
-          - |
-            OUTPUT_DIR=$(pwd)/pr
-
-            cd next-release
-            gh auth login -h github.com
-            gh pr create --head ${RELEASE_BRANCH} \
-                --title "Bumps Ad Service to latest image" \
-                --body "${PR_BODY}" \
-              > ${OUTPUT_DIR}/url
-  - task: merge-pull-request
-    params:
-      GITHUB_TOKEN: ((github.password))
-    config:
-      platform: linux
-      image_resource:
-        source:
-          repository: nixery.dev/shell/git/gh
-          tag: latest
-        type: registry-image
-      inputs:
-      - name: next-release
-      - name: pr
-      run:
-        user: root
-        path: bash
-        args:
-          - -c 
-          - |
-            PR_URL=$(cat pr/url)
-
-            set -x
-            gh auth login -h github.com
-            gh pr merge --merge --match-head-commit $(cat next-release/.git/ref) ${PR_URL}
-
-- name: release-stable
-  plan:
-  - get: next-release
-    trigger: true
-    passed:
-    - merge-stable-release
-  - get: version
-    passed:
-    - merge-stable-release
+    - release-unstable
   - load_var: version
     file: version/version
   - task: release-app
@@ -1140,12 +679,90 @@ jobs:
           - -c 
           - |
             RELEASE_NOTES="$(cat .git/commit_message)"
-    
-            /replicated release create \
+            SEQUENCE=$(/replicated release ls | grep Unstable | awk '{ print $1 ;}')
+
+            /replicated release promote ${SEQUENCE} Beta \
               --app ${REPLICATED_APP} \
               --token ${REPLICATED_API_TOKEN} \
               --version ${VERSION} \
-              --release-notes "${RELEASE_NOTES}" \
-              --yaml-dir manifests \
-              --ensure-channel \
-              --promote Stable
+              --release-notes "${RELEASE_NOTES}" 
+
+- name: promote-edge
+  plan:
+  - get: next-release
+    passed:
+    - promote-beta
+  - get: version
+    passed:
+    - promote-beta
+  - load_var: version
+    file: version/version
+  - task: release-app
+    params:
+      REPLICATED_APP: online-boutique
+      REPLICATED_API_TOKEN: ((replicated.token))
+      VERSION: ((.:version))
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: replicated/vendor-cli
+          tag: latest
+        type: registry-image
+      inputs:
+      - name: next-release
+      run:
+        user: root
+        path: sh
+        dir: next-release
+        args:
+          - -c 
+          - |
+            RELEASE_NOTES="$(cat .git/commit_message)"
+            SEQUENCE=$(/replicated release ls | grep Beta | awk '{ print $1 ;}')
+
+            /replicated release promote ${SEQUENCE} Edge \
+              --app ${REPLICATED_APP} \
+              --token ${REPLICATED_API_TOKEN} \
+              --version ${VERSION} \
+              --release-notes "${RELEASE_NOTES}" 
+
+- name: promote-stable
+  plan:
+  - get: next-release
+    passed:
+    - promote-edge
+  - get: version
+    passed:
+    - promote-edge
+  - load_var: version
+    file: version/version
+  - task: release-app
+    params:
+      REPLICATED_APP: online-boutique
+      REPLICATED_API_TOKEN: ((replicated.token))
+      VERSION: ((.:version))
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: replicated/vendor-cli
+          tag: latest
+        type: registry-image
+      inputs:
+      - name: next-release
+      run:
+        user: root
+        path: sh
+        dir: next-release
+        args:
+          - -c 
+          - |
+            RELEASE_NOTES="$(cat .git/commit_message)"
+            SEQUENCE=$(/replicated release ls | grep Edge | awk '{ print $1 ;}')
+
+            /replicated release promote ${SEQUENCE} Stable \
+              --app ${REPLICATED_APP} \
+              --token ${REPLICATED_API_TOKEN} \
+              --version ${VERSION} \
+              --release-notes "${RELEASE_NOTES}" 

--- a/ci/concourse/release.yaml
+++ b/ci/concourse/release.yaml
@@ -493,8 +493,8 @@ jobs:
               pushd next-release
                 
               # now we are in the working tree so we don't
-              if ! git diff --exit-code  ${manifest} ; then
-                echo "* ${service}" >> ${commit_message}
+              if ! git diff --exit-code  ${manifest} 2>&1 1>/dev/null ; then
+                echo "  * ${service}" >> ${commit_message}
               fi
               popd
             }

--- a/ci/concourse/shippingservice/pipeline.yaml
+++ b/ci/concourse/shippingservice/pipeline.yaml
@@ -13,7 +13,14 @@ resources:
     repository: registry.shortrib.dev/online-boutique/shippingservice
     username: ((registry.robot))
     password: ((registry.token))
-    tag: edge
+- name: version
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: online-boutique-semver
+    key: adservice-version
+    json_key: ((gcs.serviceaccountjson))
 
 jobs:
 - name: test
@@ -44,6 +51,11 @@ jobs:
     trigger: true
     passed:
     - test
+  - get: version
+    params:
+      bump: patch
+  - load_var: version
+    file: version/version
   - task: build
     privileged: true
     output_mapping:
@@ -65,6 +77,11 @@ jobs:
   - put: image
     params: 
       image: build/image.tar
+      version: ((.:version))
+      bump_aliases: true 
+  - put: version
+    params:
+      file: version/version
   
 - name: sign
   plan:


### PR DESCRIPTION
TL;DR
-----

Enables promoting across multiple release channels

Details
-------

Adds jobs to the pipeline to support releasing a new version to multiple Replicated release channels. The channels are used as follows:

* _Unstable_ All releases are delivered here at the same time as they deliver to the SaaS
* _Beta_ Enables customers who are part of the Online Boutique beta program to receives releases when approved by the release team
* _Edge_ Allows customers to opt in to receiving release on a faster timeline roughly equivalent to the SaaS deployment 
  timeline
* _Stable_ Provides for a traditional limited release cadence for more conservative end customers

All releases are to _Unstable`. Promotion across the next three channels is currently manual. There are `make` targets to promote to each one.
